### PR TITLE
Skip if the image is tif/tiff

### DIFF
--- a/src/Our.Community.MediaColourFinder/Handlers/ColourSamplingMediaHandler.cs
+++ b/src/Our.Community.MediaColourFinder/Handlers/ColourSamplingMediaHandler.cs
@@ -1,5 +1,4 @@
-﻿using Lucene.Net.Queries.Function.ValueSources;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using OurCommunityMediaColourFinder.Interfaces;
 using OurCommunityMediaColourFinder.Models;

--- a/src/Our.Community.MediaColourFinder/Handlers/ColourSamplingMediaHandler.cs
+++ b/src/Our.Community.MediaColourFinder/Handlers/ColourSamplingMediaHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Lucene.Net.Queries.Function.ValueSources;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using OurCommunityMediaColourFinder.Interfaces;
 using OurCommunityMediaColourFinder.Models;
@@ -33,6 +34,15 @@ public class ColourSamplingMediaHandler : INotificationHandler<MediaSavingNotifi
     {
         foreach (IMedia media in notification.SavedEntities)
         {
+            if (media.HasProperty("umbracoExtension"))
+            {
+                if (media.GetValue<string>("umbracoExtension")?.ToLowerInvariant() == "tif" ||
+                    media.GetValue<string>("umbracoExtension")?.ToLowerInvariant() == "tiff")
+                {
+                    continue;
+                }
+            }
+
             IEnumerable<IProperty> properties = media
                 .GetPropertiesByEditor("wsc.mediaColourFinder")
                 .ToList(); // ToList() is important here, otherwise the enumeration will be executed multiple times


### PR DESCRIPTION
We've been using the package and ran into an issue with tif images as Umbraco treats them as the Image type and Imagesharp has code that basically says they dont want to handle those filetypes.

This was the fix we used, would love to go back to an official version of the package at some point, so here is my suggested fix 🙂

closes #17 